### PR TITLE
Update middleware matcher configuration

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,5 +7,5 @@ export default auth((req) => {
     }
 })
 export const config = {
-    matcher: ["/((?!api|_next/static|_next/image|favicon.ico|la-pince-logo|reset-password|forgot-password|mentions-legales|contact|a-propos|conditions-generales|politique-privacite).*)"],
+    matcher: ['/((?!_next|api|favicon.ico).*)'],
 }


### PR DESCRIPTION
Simplified the matcher array in the middleware config to exclude only '_next', 'api', and 'favicon.ico' routes. This change streamlines route matching and may affect which routes are processed by the middleware.